### PR TITLE
🔐 Add CODEOWNERS to enforce authorship PR review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Manny27nyc


### PR DESCRIPTION
Adds .github/CODEOWNERS file to require PR reviews from @Manny27nyc before any changes to protected paths.