### PR TITLE
👮 Add CODEOWNERS policy to enforce author review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Manny27nyc


### PR DESCRIPTION
Adds .github/CODEOWNERS to require @Manny27nyc review for all pull requests per branch protection.